### PR TITLE
Consume BUILD_TAGS env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ ifeq ($(LEDGER_ENABLED),true)
     endif
   endif
 endif
+build_tags += $(BUILD_TAGS)
 build_tags := $(strip $(build_tags))
 
 whitespace :=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #266 

## What is the purpose of the change

Allows `BUILD_TAGS` to be provided for build

## Brief Changelog

- Appends env var `BUILD_TAGS` to Makefile `build_tags` similar to other cosmos-sdk chains.

## Testing and Verifying

This change is a trivial rework / code cleanup without any test coverage.

Build now succeeds on alpine linux with `BUILD_TAGS=muslc`

## Documentation and Release Note

  - Does this pull request introduce a new feature or user-facing behavior changes? no
  - Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? no
  - How is the feature or change documented? not applicable