### PR TITLE
Add LDFLAGS from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=${APP_NAME} \
 	-X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 	-X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
 	-X "github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep),cosmos-sdk $(COSMOS_SDK)"
+ldflags += $(LDFLAGS)
 
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 


### PR DESCRIPTION
Add LDFLAGS from environment variables to allow more flexibility during build

For example:
LDFLAGS="-X github.com/cosmos/cosmos-sdk/types.DBBackend=pebbledb"

## Brief Changelog

Append LDFLAGS in Makefile


## Testing and Verifying

trivial change, 

UNABLE TO TEST BECAUSE snapshot restores are broken 